### PR TITLE
Fix EmailField import

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -3,7 +3,11 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, SubmitField, IntegerField, SelectField
 from wtforms.validators import DataRequired, Email, EqualTo, Length, NumberRange
-from wtforms.fields.html5 import EmailField
+try:
+    # WTForms >=3 removed the html5 module; fall back to new location
+    from wtforms.fields import EmailField
+except ImportError:  # pragma: no cover - fallback for WTForms<3
+    from wtforms.fields.html5 import EmailField
 
 
 class RegistrationForm(FlaskForm):


### PR DESCRIPTION
## Summary
- repair obsolete EmailField import in forms

## Testing
- `pytest -q`
- `python -m py_compile app.py forms.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_684166b5b59c832da87a63158729094d